### PR TITLE
Corrected file deletion bugs and renamed vars in DeleteTask & FileUtil

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/DeleteTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/DeleteTask.java
@@ -73,14 +73,13 @@ public class DeleteTask extends AsyncTask<ArrayList<HybridFileParcelable>, Strin
 
     protected Boolean doInBackground(ArrayList<HybridFileParcelable>... p1) {
         files = p1[0];
-        boolean b = true;
+        boolean wasDeleted = true;
         if(files.size()==0)return true;
 
         if (files.get(0).isOtgFile()) {
-            for (HybridFileParcelable a : files) {
-
-                DocumentFile documentFile = OTGUtil.getDocumentFile(a.getPath(), cd, false);
-                 b = documentFile.delete();
+            for (HybridFileParcelable file : files) {
+                DocumentFile documentFile = OTGUtil.getDocumentFile(file.getPath(), cd, false);
+                wasDeleted = documentFile.delete();
             }
         } else if (files.get(0).isDropBoxFile()) {
             CloudStorage cloudStorageDropbox = dataUtils.getAccount(OpenMode.DROPBOX);
@@ -89,7 +88,7 @@ public class DeleteTask extends AsyncTask<ArrayList<HybridFileParcelable>, Strin
                     cloudStorageDropbox.delete(CloudUtil.stripPath(OpenMode.DROPBOX, baseFile.getPath()));
                 } catch (Exception e) {
                     e.printStackTrace();
-                    b = false;
+                    wasDeleted = false;
                     break;
                 }
             }
@@ -100,7 +99,7 @@ public class DeleteTask extends AsyncTask<ArrayList<HybridFileParcelable>, Strin
                     cloudStorageBox.delete(CloudUtil.stripPath(OpenMode.BOX, baseFile.getPath()));
                 } catch (Exception e) {
                     e.printStackTrace();
-                    b = false;
+                    wasDeleted = false;
                     break;
                 }
             }
@@ -111,7 +110,7 @@ public class DeleteTask extends AsyncTask<ArrayList<HybridFileParcelable>, Strin
                     cloudStorageGdrive.delete(CloudUtil.stripPath(OpenMode.GDRIVE, baseFile.getPath()));
                 } catch (Exception e) {
                     e.printStackTrace();
-                    b = false;
+                    wasDeleted = false;
                     break;
                 }
             }
@@ -122,23 +121,23 @@ public class DeleteTask extends AsyncTask<ArrayList<HybridFileParcelable>, Strin
                     cloudStorageOnedrive.delete(CloudUtil.stripPath(OpenMode.ONEDRIVE, baseFile.getPath()));
                 } catch (Exception e) {
                     e.printStackTrace();
-                    b = false;
+                    wasDeleted = false;
                     break;
                 }
             }
         } else {
-            for(HybridFileParcelable a : files) {
+            for(HybridFileParcelable file : files) {
                 try {
-                    boolean result = (a).delete(cd, rootMode);
-                    if (!result && b) {
-                        b = false;
-                        return b;
+                    if (file.delete(cd, rootMode)) {
+                        wasDeleted = true;
+                    } else {
+                        wasDeleted = false;
+                        break;
                     }
-                    else
-                        b = true;
                 } catch (ShellNotRunningException e) {
                     e.printStackTrace();
-                    b = false;
+                    wasDeleted = false;
+                    break;
                 }
             }
         }
@@ -164,18 +163,18 @@ public class DeleteTask extends AsyncTask<ArrayList<HybridFileParcelable>, Strin
             }
         }
 
-        return b;
+        return wasDeleted;
     }
 
     @Override
-    public void onPostExecute(Boolean b) {
+    public void onPostExecute(Boolean wasDeleted) {
 
         Intent intent = new Intent(MainActivity.KEY_INTENT_LOAD_LIST);
         String path = files.get(0).getParent(cd);
         intent.putExtra(MainActivity.KEY_INTENT_LOAD_LIST_FILE, path);
         cd.sendBroadcast(intent);
 
-        if (!b) {
+        if (!wasDeleted) {
             Toast.makeText(cd, cd.getResources().getString(R.string.error), Toast.LENGTH_SHORT).show();
         } else if (compressedExplorerFragment ==null) {
             Toast.makeText(cd, cd.getResources().getString(R.string.done), Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/FileUtil.java
@@ -12,6 +12,7 @@ import android.preference.PreferenceManager;
 import android.provider.BaseColumns;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.provider.DocumentFile;
 import android.util.Log;
 
@@ -530,16 +531,13 @@ public abstract class FileUtil {
      * @return true if successful.
      */
     private static boolean rmdir(final File file, Context context) {
-
-        if (file == null)
-            return false;
-        if (!file.exists())
-            return true;
+        if (!file.exists()) return true;
 
         File[] files = file.listFiles();
         if (files != null && files.length > 0) {
-            for(File _file : files)
-                rmdir(_file, context);
+            for(File child : files) {
+                rmdir(child, context);
+            }
         }
 
         // Try the normal way
@@ -550,7 +548,9 @@ public abstract class FileUtil {
         // Try with Storage Access Framework.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             DocumentFile document = getDocumentFile(file, true, context);
-            return (document != null) ? document.delete() : false;
+            if(document != null && document.delete()) {
+                return true;
+            }
         }
 
         // Try the Kitkat workaround.


### PR DESCRIPTION
* Corrected [DeleteTask@135](https://github.com/TranceLove/AmazeFileManager/compare/bugfix/issue1102...EmmanuelMess:fix-deletetask#diff-50f9a93eb9db9ace5cdd72088327351fL135) and [FileUtil@553](https://github.com/TranceLove/AmazeFileManager/compare/bugfix/issue1102...EmmanuelMess:fix-deletetask#diff-fb33ac4976161d80b01c3a8a2f8ce657L553) immediately returning after file deletion failure
* rmdir() and deleteFile()'s parameters are now annotated as NonNull, removed unnecessary checks
* Renamed vars in DeleteTask & FileUtil

PS: Check if I have not made horrendous mistakes, I am tired.