### PR TITLE
 Return ArrayList from RootHelper.runShellCommand()

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/filesystem/RootHelper.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/RootHelper.java
@@ -44,10 +44,10 @@ public class RootHelper {
      * @return a list of results. Null only if the command passed is a blocking call or no output is
      * there for the command passed
      */
-    public static List<String> runShellCommand(String cmd) throws ShellNotRunningException {
+    public static ArrayList<String> runShellCommand(String cmd) throws ShellNotRunningException {
         if (MainActivity.shellInteractive == null || !MainActivity.shellInteractive.isRunning())
             throw new ShellNotRunningException();
-        final List<String> result = new ArrayList<>();
+        final ArrayList<String> result = new ArrayList<>();
 
         // callback being called on a background handler thread
         MainActivity.shellInteractive.addCommand(cmd, 0, (commandCode, exitCode, output) -> result.addAll(output));
@@ -217,7 +217,7 @@ public class RootHelper {
         String name = f.getName();
         String p = f.getParent();
         if (p != null && p.length() > 0) {
-            List<String> ls = runShellCommand("ls -l " + p);
+            ArrayList<String> ls = runShellCommand("ls -l " + p);
             for (String s : ls) {
                 if (contains(s.split(" "), name)) {
                     try {

--- a/app/src/main/java/com/amaze/filemanager/utils/RootUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/RootUtils.java
@@ -7,6 +7,8 @@ package com.amaze.filemanager.utils;
 import com.amaze.filemanager.exceptions.ShellNotRunningException;
 import com.amaze.filemanager.filesystem.RootHelper;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -37,7 +39,7 @@ public class RootUtils {
      */
     private static String mountFileSystemRW(String path) throws ShellNotRunningException {
         String command = "mount";
-        List<String> output = RootHelper.runShellCommand(command);
+        ArrayList<String> output = RootHelper.runShellCommand(command);
         String mountPoint = "", types = null;
         for (String line : output) {
             String[] words = line.split(" ");
@@ -61,7 +63,7 @@ public class RootUtils {
             } else if (types.contains("ro")) {
                 // read-only file system, remount as rw
                 String mountCommand = "mount -o rw,remount " + mountPoint;
-                List<String> mountOutput = RootHelper.runShellCommand(mountCommand);
+                ArrayList<String> mountOutput = RootHelper.runShellCommand(mountCommand);
 
                 if (mountOutput.size() != 0) {
                     // command failed, and we got a reason echo'ed
@@ -134,7 +136,7 @@ public class RootUtils {
      * Method requires busybox
      */
     private static int getFilePermissions(String path) throws ShellNotRunningException {
-        String line = RootHelper.runShellCommand("stat -c  %a \"" + path + "\"").iterator().next();
+        String line = RootHelper.runShellCommand("stat -c  %a \"" + path + "\"").get(0);
 
         return Integer.valueOf(line);
     }
@@ -146,7 +148,7 @@ public class RootUtils {
      */
     public static boolean delete(String path) throws ShellNotRunningException {
         String mountPoint = mountFileSystemRW(path);
-        List<String> result = RootHelper.runShellCommand("rm -rf \"" + path + "\"");
+        ArrayList<String> result = RootHelper.runShellCommand("rm -rf \"" + path + "\"");
 
         if (mountPoint != null) {
             // we mounted the filesystem as rw, let's mount it back to ro
@@ -181,7 +183,7 @@ public class RootUtils {
      */
     public static boolean rename(String oldPath, String newPath) throws ShellNotRunningException {
         String mountPoint = mountFileSystemRW(oldPath);
-        List<String> output = RootHelper.runShellCommand("mv \"" + oldPath + "\" \"" + newPath + "\"");
+        ArrayList<String> output = RootHelper.runShellCommand("mv \"" + oldPath + "\" \"" + newPath + "\"");
 
         if (mountPoint != null) {
             // we mounted the filesystem as rw, let's mount it back to ro


### PR DESCRIPTION
Someone going to modify a `List` will probably copy it: `new ArrayList(oldList)` incurring in an unnecessary computational cost if the `List` is already an `ArrayList` and is not needed later in it's original form.